### PR TITLE
Add PubSub support for mockredis

### DIFF
--- a/mockredis/client.py
+++ b/mockredis/client.py
@@ -19,6 +19,7 @@ from mockredis.exceptions import RedisError, ResponseError, WatchError
 from mockredis.pipeline import MockRedisPipeline
 from mockredis.script import Script
 from mockredis.sortedset import SortedSet
+from mockredis.pubsub import Pubsub
 
 if sys.version_info >= (3, 0):
     long = int
@@ -59,8 +60,7 @@ class MockRedis(object):
         self.redis = defaultdict(dict)
         self.redis_config = defaultdict(dict)
         self.timeouts = defaultdict(dict)
-        # The 'PubSub' store
-        self.pubsub = defaultdict(list)
+        self._pubsub = None
         # Dictionary from script to sha ''Script''
         self.shas = dict()
         self.decode_responses = decode_responses
@@ -282,7 +282,7 @@ class MockRedis(object):
 
     def flushdb(self):
         self.redis.clear()
-        self.pubsub.clear()
+        self.pubsub().clear()
         self.timeouts.clear()
 
     def rename(self, old_key, new_key):
@@ -1449,8 +1449,14 @@ class MockRedis(object):
 
     # PubSub commands #
 
+    def pubsub(self, **kwargs):
+        """ Return a mocked 'PubSub' object """
+        if not self._pubsub:
+            self._pubsub = Pubsub(self, **kwargs)
+        return self._pubsub
+
     def publish(self, channel, message):
-        self.pubsub[channel].append(message)
+        self.pubsub().publish(channel, message)
 
     # Internal #
 

--- a/mockredis/pubsub.py
+++ b/mockredis/pubsub.py
@@ -1,0 +1,79 @@
+class Pubsub(dict):
+    def __init__(self, connection_pool, shard_hint=None, ignore_subscribe_messages=False):
+        # there is no connection pool, but we want a reference to the parent
+        self.redis = connection_pool
+        self.shard_hint = shard_hint
+        self.ignore_subscribe_messages = ignore_subscribe_messages
+
+        self.channels = []
+        self.patterns = []
+
+    def publish(self, channel, message):
+        """emulate publish"""
+        if channel not in self:
+            self.channels.append(channel)
+            self[channel] = []
+
+        self[channel].append(message)
+
+    def reset(self):
+        """emulate reset"""
+        self.clear()
+        self.channels = []
+
+    def close(self):
+        """emulate close"""
+        self.reset()
+
+    def encode(self, value):
+        """emulate encode by calling the parent's"""
+        return self.redis._encode(value)
+
+    def on_connect(self, connection):
+        """do nothing while mocking"""
+        pass
+
+    @property
+    def subscribed(self):
+        """emulate subscribed"""
+        return bool(self.channels or self.patterns)
+
+    def execute_command(self, *args, **kwargs):
+        """do nothing while mocking"""
+        return
+
+    def parse_response(self, block=True, timeout=0):
+        """do nothing while mocking"""
+        return
+
+    def psubscribe(self, *args, **kwargs):
+        """call no callbacks while mocking"""
+        return
+
+    def punsubscribe(self, *args, **kwargs):
+        """call no callbacks while mocking"""
+        return
+
+    def subscribe(self, *args, **kwargs):
+        """call no callbacks while mocking"""
+        return
+
+    def unsubscribe(self, *args, **kwargs):
+        """call no callbacks while mocking"""
+        return
+
+    def listen(self):
+        """do nothing while mocking"""
+        return
+
+    def get_message(self, ignore_subscribe_messages=False, timeout=0):
+        """do nothing while mocking"""
+        return
+
+    def handle_message(self, response, ignore_subscribe_messages=False):
+        """do nothing while mocking"""
+        return
+
+    def run_in_thread(self, sleep_time=0):
+        """do nothing while mocking"""
+        return


### PR DESCRIPTION
The original pubsub implementation didn't actually work
fully, it's supposed to be a callable.

So I've implemented much more of it, enough to mock reasonably.
You do basic things like publish messages, but most everything else
is just a no-op.  Most of what pubsub does doesn't really work well
when mocking anyway, so this is good enough to deal with the basics.

Feel free to suggest more functionality - I only need the basics,
but I'd be happy to do a bit more on this if needed.